### PR TITLE
Feat/그룹 조회 기능 추가 - 스터디 주제 이름 검색어 조건 추가 (#100)

### DIFF
--- a/src/main/java/com/jxx/xuni/group/query/GroupQueryImpl.java
+++ b/src/main/java/com/jxx/xuni/group/query/GroupQueryImpl.java
@@ -42,7 +42,8 @@ public class GroupQueryImpl implements GroupQuery {
                 .from(group)
                 .where(
                         categoryEqual(condition.getCategory()),
-                        readTypeCond(condition.getReadType())
+                        readTypeCond(condition.getReadType()),
+                        studySubjectContain(condition.getSubject())
                 )
                 .offset(pageable.getOffset())
                 .limit(QueryLimitPolicy.LIMIT_OF_PAGE)
@@ -73,6 +74,10 @@ public class GroupQueryImpl implements GroupQuery {
         }
 
         return new OrderSpecifier(direction, group.period.startDate);
+    }
+
+    private BooleanExpression studySubjectContain(String subject) {
+        return subject != null && !subject.isEmpty() ? group.study.subject.contains(subject) : null;
     }
 
     private BooleanExpression categoryEqual(Category category) {

--- a/src/main/java/com/jxx/xuni/group/query/dynamic/GroupSearchCondition.java
+++ b/src/main/java/com/jxx/xuni/group/query/dynamic/GroupSearchCondition.java
@@ -7,12 +7,14 @@ public class GroupSearchCondition {
     private String readType;
     private Boolean isAsc;
     private String sortProperty;
+    private String subject;
 
-    public GroupSearchCondition(Category category, String readType, Boolean isAsc, String sortProperty) {
+    public GroupSearchCondition(Category category, String readType, Boolean isAsc, String sortProperty, String subject) {
         this.category = category;
         this.readType = readType;
         this.isAsc = isAsc;
         this.sortProperty = sortProperty;
+        this.subject = subject;
     }
 
     public void nullHandle() {
@@ -33,5 +35,9 @@ public class GroupSearchCondition {
 
     public Boolean isAsc() {
         return isAsc;
+    }
+
+    public String getSubject() {
+        return subject;
     }
 }

--- a/src/test/java/com/jxx/xuni/group/domain/TestGroupServiceSupporter.java
+++ b/src/test/java/com/jxx/xuni/group/domain/TestGroupServiceSupporter.java
@@ -35,7 +35,7 @@ public class TestGroupServiceSupporter {
         return new Group(Period.of(LocalDate.now(), LocalDate.of(2023, 12, 31)),
                 Time.of(LocalTime.MIDNIGHT, LocalTime.NOON),
                 new Capacity(5),
-                Study.of("UUID","자바의 정석", category),
+                Study.of("UUID","Real MySQL", category),
                 new Host(1l, "재헌"));
     }
 

--- a/src/test/java/com/jxx/xuni/group/presentation/GroupReadControllerTest.java
+++ b/src/test/java/com/jxx/xuni/group/presentation/GroupReadControllerTest.java
@@ -298,6 +298,7 @@ class GroupReadControllerTest extends GroupCommon {
                 .param("isAsc", "true")
                 .param("sortProperty", "start-date")
                 .param("page", "0")
+                .param("subject","")
                 .contentType(MediaType.APPLICATION_JSON));
 
         result
@@ -308,11 +309,12 @@ class GroupReadControllerTest extends GroupCommon {
                         getDocumentRequest(), getDocumentResponse(),
 
                         queryParameters(
-                                RequestDocumentation.parameterWithName("category").description("스터디 주제"),
-                                RequestDocumentation.parameterWithName("readType").description("조회할 그룹 상태"),
-                                RequestDocumentation.parameterWithName("isAsc").description("오름차순 여부"),
-                                RequestDocumentation.parameterWithName("sortProperty").description("정렬 기준이 되는 속성"),
-                                RequestDocumentation.parameterWithName("page").description("현재 페이지")
+                                parameterWithName("category").description("스터디 주제"),
+                                parameterWithName("readType").description("조회할 그룹 상태"),
+                                parameterWithName("isAsc").description("오름차순 여부"),
+                                parameterWithName("sortProperty").description("정렬 기준이 되는 속성"),
+                                parameterWithName("subject").description("검색 입력어 (스터디 주제 이름)"),
+                                parameterWithName("page").description("현재 페이지")
                                 ),
 
                         responseFields(
@@ -381,8 +383,8 @@ class GroupReadControllerTest extends GroupCommon {
                                         HeaderDocumentation.headerWithName("Authorization").description("인증 토큰")
                                 ),
 
-                                RequestDocumentation.pathParameters(
-                                        RequestDocumentation.parameterWithName("group-id").description("그룹 식별자")
+                                pathParameters(
+                                        parameterWithName("group-id").description("그룹 식별자")
                                 ),
 
                                 PayloadDocumentation.responseFields(
@@ -436,8 +438,8 @@ class GroupReadControllerTest extends GroupCommon {
 
                 .andDo(MockMvcRestDocumentation.document("group/query/readOwn",
 
-                        RequestDocumentation.pathParameters(
-                                RequestDocumentation.parameterWithName("member-id").description("회원 식별자")
+                        pathParameters(
+                                parameterWithName("member-id").description("회원 식별자")
                         ),
 
                         HeaderDocumentation.requestHeaders(

--- a/src/test/java/com/jxx/xuni/group/query/GroupQueryImplTest.java
+++ b/src/test/java/com/jxx/xuni/group/query/GroupQueryImplTest.java
@@ -67,7 +67,7 @@ class GroupQueryImplTest {
                 nullValues = "null", emptyValue = "empty")
     void search_group_no_set_any_condition(String description, Category category, String readType) {
         //given
-        GroupSearchCondition condition = new GroupSearchCondition(category, readType, false, null);
+        GroupSearchCondition condition = new GroupSearchCondition(category, readType, false, null, null);
         Integer forceInjectValue = 100;
         PageRequest pageable = PageRequest.of(0, forceInjectValue);
         //when
@@ -85,7 +85,7 @@ class GroupQueryImplTest {
     @Test
     void search_group_category_condition() {
         //given
-        GroupSearchCondition condition = new GroupSearchCondition(MYSQL, null, false, null);
+        GroupSearchCondition condition = new GroupSearchCondition(MYSQL, null, false, null, null);
         PageRequest pageable = PageRequest.of(0, 20);
         //when
         List<GroupAllQueryResponse> content = groupReadRepository.searchGroup(condition, pageable).getContent();
@@ -99,7 +99,7 @@ class GroupQueryImplTest {
     @DisplayName("읽기 타입 조건을 검증한다. all 일 경우, GroupStatus = GATHERING, GATHER_COMPLETE, START, END 모두 조회한다.")
     @Test
     void search_group_read_type_condition_all() {
-        GroupSearchCondition condition = new GroupSearchCondition(null, "all", false, null);
+        GroupSearchCondition condition = new GroupSearchCondition(null, "all", false, null, null);
         PageRequest pageable = PageRequest.of(0, 20);
         //when
         List<GroupAllQueryResponse> content = groupReadRepository.searchGroup(condition, pageable).getContent();
@@ -110,7 +110,7 @@ class GroupQueryImplTest {
     @DisplayName("읽기 타입 조건을 검증한다. gathering 일 경우, GroupStatus = GATHERING 만 조회한다.")
     @Test
     void search_group_read_type_condition_gathering() {
-        GroupSearchCondition condition = new GroupSearchCondition(null, "gathering", false, null);
+        GroupSearchCondition condition = new GroupSearchCondition(null, "gathering", false, null, null);
         PageRequest pageable = PageRequest.of(0, 20);
         //when
         List<GroupAllQueryResponse> content = groupReadRepository.searchGroup(condition, pageable).getContent();
@@ -121,7 +121,7 @@ class GroupQueryImplTest {
     @DisplayName("읽기 타입 조건을 검증한다. default 일 경우, GroupStatus = GATHERING, GATHER_COMPLETE, START 만 조회한다.")
     @Test
     void search_group_read_type_condition_default() {
-        GroupSearchCondition condition = new GroupSearchCondition(null, "default", false, null);
+        GroupSearchCondition condition = new GroupSearchCondition(null, "default", false, null, null);
         PageRequest pageable = PageRequest.of(0, 20);
         //when
         List<GroupAllQueryResponse> content = groupReadRepository.searchGroup(condition, pageable).getContent();
@@ -132,11 +132,24 @@ class GroupQueryImplTest {
     @DisplayName("읽기 타입 조건을 검증한다. 그 외 값이 들어올 경우 GroupStatus = GATHERING, GATHER_COMPLETE, START 만 조회한다.")
     @Test
     void search_group_read_type_condition_other_value() {
-        GroupSearchCondition condition = new GroupSearchCondition(null, "otherValue", false, null);
+        GroupSearchCondition condition = new GroupSearchCondition(null, "otherValue", false, null, null);
         PageRequest pageable = PageRequest.of(0, 20);
         //when
         List<GroupAllQueryResponse> content = groupReadRepository.searchGroup(condition, pageable).getContent();
         //then
         assertThat(content).extracting("groupStatus").containsOnly(GATHERING, GATHER_COMPLETE, START);
+    }
+
+    @DisplayName("입력어 조건을 검증한다. 입력어가 포함(일치가 아니다.)되어 있는 그룹만 조회한다.")
+    @Test
+    void search_group_subject_condition() {
+        GroupSearchCondition condition = new GroupSearchCondition(null, null, false, null, "MySQL");
+        PageRequest pageable = PageRequest.of(0, 20);
+        //when
+        List<GroupAllQueryResponse> content = groupReadRepository.searchGroup(condition, pageable).getContent();
+        //then
+
+        assertThat(content).extracting("study.subject").containsOnly("Real MySQL");
+
     }
 }


### PR DESCRIPTION
1. 스터디 그룹은 특정 스터디 주제를 가지고 그룹을 개설한다. 스터디 주제는 각자만의 고유한 이름을 가진다. 여기서 스터디 주제란 Java의 정석, 도메인 주도 개발 시작하기 등 책, 혹은 강의의 이름을 말한다.