### PR TITLE
Feat/로그인 시 유저 식별자 응답에 추가 (#195)

### DIFF
--- a/src/main/java/com/jxx/xuni/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/jxx/xuni/auth/dto/response/LoginResponse.java
@@ -7,13 +7,15 @@ import lombok.Getter;
 public class LoginResponse {
     private final String email;
     private final String name;
+    private final Long userId;
 
-    public LoginResponse(String email, String name) {
+    public LoginResponse(String email, String name, Long userId) {
         this.email = email;
         this.name = name;
+        this.userId = userId;
     }
 
     public static LoginResponse from(MemberDetails memberDetails) {
-        return new LoginResponse(memberDetails.getEmail(), memberDetails.getName());
+        return new LoginResponse(memberDetails.getEmail(), memberDetails.getName(), memberDetails.getUserId());
     }
 }

--- a/src/test/java/com/jxx/xuni/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/jxx/xuni/auth/presentation/AuthControllerTest.java
@@ -128,13 +128,22 @@ class AuthControllerTest extends AuthCommon{
                     ));
     }
 
+    class MockMemberDetails extends SimpleMemberDetails {
+
+        private String mockField;
+
+        public MockMemberDetails(Long userId, String email, String name, String mockField) {
+            super(userId, email, name);
+            this.mockField = mockField;
+        }
+    }
+
     @DisplayName("로그인 API")
     @Test
     void login_docs() throws Exception {
         LoginForm form = new LoginForm("leesin5498@xuni.com", "0000");
-
-        MemberDetails memberDetails = new SimpleMemberDetails(any(), "leesin5498@xuni.com", "김유니");
-        BDDMockito.given(authService.login(form)).willReturn(memberDetails);
+        MockMemberDetails mockMemberDetails = new MockMemberDetails(1l, "leesin5498@xuni.com", "김유니", any());
+        BDDMockito.given(authService.login(form)).willReturn(mockMemberDetails);
 
         ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/auth/login")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -156,7 +165,8 @@ class AuthControllerTest extends AuthCommon{
 
                                 fieldWithPath("response").type(JsonFieldType.OBJECT).description("응답 본문"),
                                 fieldWithPath("response.email").type(JsonFieldType.STRING).description("이메일"),
-                                fieldWithPath("response.name").type(JsonFieldType.STRING).description("이름")
+                                fieldWithPath("response.name").type(JsonFieldType.STRING).description("이름"),
+                                fieldWithPath("response.userId").type(JsonFieldType.NUMBER).description("유저 식별자")
                         ),
 
                         HeaderDocumentation.responseHeaders(


### PR DESCRIPTION
1. given(), willReturn() 양측에 모킹을 할 수 없는 문제 해결 : Mock 응답 객체를 만들어 테스트만을 위한 객체 추가