### PR TITLE
Feat/로그인 시 유저 식별자 응답에 추가 (#143)

### DIFF
--- a/src/main/java/com/jxx/xuni/auth/config/AuthInterceptorConfig.java
+++ b/src/main/java/com/jxx/xuni/auth/config/AuthInterceptorConfig.java
@@ -62,6 +62,7 @@ public class AuthInterceptorConfig implements WebMvcConfigurer{
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3030")
                 .exposedHeaders("Authorization")
+                .allowCredentials(true) // 클라이언트에서 Authorization 헤더를 보낼 때는 붙이는게 규정같음
                 .allowedMethods("GET","POST","PATCH","PUT","DELETE","OPTIONS");
     }
 }

--- a/src/main/java/com/jxx/xuni/auth/presentation/AdminInterceptor.java
+++ b/src/main/java/com/jxx/xuni/auth/presentation/AdminInterceptor.java
@@ -22,6 +22,10 @@ public class AdminInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if ("OPTIONS".equals(request.getMethod())) {
+            return true;
+        }
+
         Method method = getMethod(handler);
         if (isNotAdmin(method)) {
             return true;

--- a/src/main/java/com/jxx/xuni/auth/presentation/JwtAuthInterceptor.java
+++ b/src/main/java/com/jxx/xuni/auth/presentation/JwtAuthInterceptor.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.servlet.HandlerInterceptor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.List;
 
 import static com.jxx.xuni.common.exception.CommonExceptionMessage.REQUIRED_LOGIN;
 
@@ -17,7 +16,7 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        if (notRequiredAuthentication(request)) {
+        if (notRequiredAuthentication(request) || "OPTIONS".equals(request.getMethod())) {
             return true;
         }
 


### PR DESCRIPTION
1. 인터셉터 단에서 OPTIONS 메서드는 검증하지 않도록 변경 OPTIONS 메서드에는 HTTP 헤더가 미포함이여서 인터셉터 요청을 수행할 수 없음

2. withCredentials 설정