### PR TITLE
Refactor/그룹 도메인 리팩터링 (#216)

### DIFF
--- a/src/main/java/com/jxx/xuni/group/domain/Capacity.java
+++ b/src/main/java/com/jxx/xuni/group/domain/Capacity.java
@@ -1,9 +1,12 @@
 package com.jxx.xuni.group.domain;
 
+import com.jxx.xuni.group.domain.exception.CapacityOutOfBoundException;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static com.jxx.xuni.group.dto.response.GroupApiMessage.NOT_APPROPRIATE_GROUP_CAPACITY;
 
 
 @Getter
@@ -24,6 +27,11 @@ public class Capacity {
     public static Capacity of(Integer capacity) {
         return new Capacity(capacity);
     }
+
+    protected boolean hasNotTotalCapacityWithinRange(){
+        return totalCapacity < CAPACITY_MIN || totalCapacity > CAPACITY_MAX;
+    }
+
     protected void subtractOneLeftCapacity() {
         this.leftCapacity -= 1;
     }

--- a/src/main/java/com/jxx/xuni/group/domain/GroupMember.java
+++ b/src/main/java/com/jxx/xuni/group/domain/GroupMember.java
@@ -33,7 +33,11 @@ public class GroupMember {
         this.group = group;
     }
 
-    protected boolean hasSameId(Long groupMemberId) {
+    public static GroupMember enrollHost(Host host, Group group) {
+        return new GroupMember(host.getHostId(), host.getHostName(), group);
+    }
+
+    protected boolean hasEqualId(Long groupMemberId) {
         return this.groupMemberId.equals(groupMemberId);
     }
 

--- a/src/main/java/com/jxx/xuni/group/domain/Task.java
+++ b/src/main/java/com/jxx/xuni/group/domain/Task.java
@@ -31,7 +31,7 @@ public class Task {
         this.group =  group;
     }
 
-    public static Task init(Long memberId, Long chapterId, String title, Group group) {
+    public static Task initialize(Long memberId, Long chapterId, String title, Group group) {
         return new Task(memberId, chapterId, title, false, group);
     }
 
@@ -43,7 +43,7 @@ public class Task {
         return this.chapterId.equals(chapterId);
     }
 
-    public boolean isSameMember(Long memberId) {
+    public boolean isEqualMemberId(Long memberId) {
         return this.memberId.equals(memberId);
     }
 }

--- a/src/test/java/com/jxx/xuni/group/domain/GroupTest.java
+++ b/src/test/java/com/jxx/xuni/group/domain/GroupTest.java
@@ -49,7 +49,7 @@ class GroupTest {
         assertThat(group.getGroupStatus()).isEqualTo(GroupStatus.GATHERING);
 
         assertThat(group.getGroupMembers().stream()
-                .anyMatch(groupMember -> groupMember.hasSameId(group.getHost().getHostId()))).isTrue();
+                .anyMatch(groupMember -> groupMember.hasEqualId(group.getHost().getHostId()))).isTrue();
     }
 
     @DisplayName("스터디 그룹의 인원은 최소 1인에서 최대 20인 까지 가능합니다. " +
@@ -58,7 +58,8 @@ class GroupTest {
     @ValueSource(ints = {-1, 0, 21})
     void check_group_capacity(Integer capacity) {
         Group group = makeTestGroup(capacity);
-        assertThatThrownBy(() -> group.checkCapacityRange()).isInstanceOf(CapacityOutOfBoundException.class);
+        assertThatThrownBy(() -> group.checkCapacityRange())
+                .isInstanceOf(CapacityOutOfBoundException.class);
     }
 
     @DisplayName("초기 가입")
@@ -85,7 +86,7 @@ class GroupTest {
         group.join(groupMember);
 
         GroupMember findGroupMember = group.getGroupMembers().stream()
-                .filter(g -> g.hasSameId(2l)).findFirst().get();
+                .filter(g -> g.hasEqualId(2l)).findFirst().get();
 
         group.leave(2l);
 
@@ -277,7 +278,7 @@ class GroupTest {
         group.leave(2l);
         //then - isLeft 프로퍼티가 True 로 변경되었는지 검증
         GroupMember findGroupMember = group.getGroupMembers().stream()
-                .filter(g -> g.hasSameId(2l))
+                .filter(g -> g.hasEqualId(2l))
                 .findAny().get();
         assertThat(findGroupMember.getIsLeft()).isTrue();
 
@@ -364,7 +365,7 @@ class GroupTest {
         group.doTask(2l, 1l);
 
         Task studyCheckAfterVerifyCheckRule = group.getTasks().stream()
-                .filter(s -> s.isSameMember(1l))
+                .filter(s -> s.isEqualMemberId(1l))
                 .filter(s -> s.isSameChapter(2l)).findAny().get();
         //then
         assertThat(studyCheckAfterVerifyCheckRule.isDone()).isTrue();
@@ -378,7 +379,7 @@ class GroupTest {
         //given - 그룹 시작 상태로 변경
         Group group = makeTestGroup(5);
         group.changeGroupStatusTo(status);
-        group.initGroupTask(TestGroupServiceSupporter.studyCheckForms);
+        group.initializeGroupTask(TestGroupServiceSupporter.studyCheckForms);
 
         //when - then
         assertThatThrownBy(() -> group.doTask(2l, 1l))
@@ -393,7 +394,7 @@ class GroupTest {
         //given - 그룹 시작 상태로 변경
         Group group = makeTestGroup(5);
         group.changeGroupStatusTo(START);
-        group.initGroupTask(TestGroupServiceSupporter.studyCheckForms); // chapter 는 1,2,3 까지 존재합니다.
+        group.initializeGroupTask(TestGroupServiceSupporter.studyCheckForms); // chapter 는 1,2,3 까지 존재합니다.
 
         //when - then
         //

--- a/src/test/java/com/jxx/xuni/group/domain/TaskTest.java
+++ b/src/test/java/com/jxx/xuni/group/domain/TaskTest.java
@@ -14,7 +14,7 @@ class TaskTest {
     @Test
     void check() {
         //given
-        Task task = Task.init(1l, 1l, "spring loc", null);
+        Task task = Task.initialize(1l, 1l, "spring loc", null);
         Assertions.assertThat(task.isDone()).isFalse();
         //when
         task.updateDone();


### PR DESCRIPTION
1. 동등성이라는 의미를 명확하게 표현하기 위해 메서드 명 변경 same -> equal

2. 메서드 내 캡슐화되어 있는 기능의 흐름을 더 파악할 수 있도록 메서드 순서 변경

3. 축약된 용여 풀어서 표현 init -> initialize