### PR TITLE
Refactor/쿼리 최적화를 위한 Review 테이블 구조 변경 (#228)

### DIFF
--- a/src/main/java/com/jxx/xuni/review/application/ReviewLikeService.java
+++ b/src/main/java/com/jxx/xuni/review/application/ReviewLikeService.java
@@ -1,8 +1,6 @@
 package com.jxx.xuni.review.application;
 
-import com.jxx.xuni.review.domain.LikeStatus;
-import com.jxx.xuni.review.domain.ReviewLike;
-import com.jxx.xuni.review.domain.ReviewLikeRepository;
+import com.jxx.xuni.review.domain.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,18 +12,19 @@ import java.util.Optional;
 public class ReviewLikeService {
 
     private final ReviewLikeRepository reviewLikeRepository;
+    private final ReviewRepository reviewRepository;
 
     @Transactional
     public LikeStatus execute(Long reviewId, Long memberId) {
-        Optional<ReviewLike> optionalReviewLike = reviewLikeRepository.findByReviewIdAndMemberId(reviewId, memberId);
+        Optional<ReviewLike> optionalReviewLike = reviewLikeRepository.readWithReviewFetch(reviewId, memberId);
         if (optionalReviewLike.isPresent()) {
             ReviewLike reviewLike = optionalReviewLike.get();
             reviewLike.execute();
             return reviewLike.getLikeStatus();
         }
 
-        ReviewLike reviewLike = new ReviewLike(reviewId, memberId);
-        ReviewLike savedReviewLike = reviewLikeRepository.save(reviewLike);
-        return savedReviewLike.getLikeStatus();
+        Review review = reviewRepository.findById(reviewId).get();
+        ReviewLike reviewLike = reviewLikeRepository.save(new ReviewLike(memberId, review));
+        return reviewLike.getLikeStatus();
     }
 }

--- a/src/main/java/com/jxx/xuni/review/application/ReviewService.java
+++ b/src/main/java/com/jxx/xuni/review/application/ReviewService.java
@@ -41,15 +41,15 @@ public class ReviewService {
     public List<ReviewOneResponse> read(String studyProductId) {
         List<Review> reviews = reviewRepository.readBy(studyProductId);
 
-        return reviews.stream().map(r -> new ReviewOneResponse(
-                r.getId(),
-                r.receiveComment(),
-                r.receiveRating(),
-                r.getLastModifiedTime(),
-                r.receiveReviewerId(),
-                r.receiveReviewerName(),
-                r.receiveProgress(),
-                reviewRepository.countReviewLike(r.getId()))).toList();
+        return reviews.stream().map(review -> new ReviewOneResponse(
+                review.getId(),
+                review.receiveComment(),
+                review.receiveRating(),
+                review.getLastModifiedTime(),
+                review.receiveReviewerId(),
+                review.receiveReviewerName(),
+                review.receiveProgress(),
+                review.getLikeTotalCnt())).toList();
     }
 
     @Transactional

--- a/src/main/java/com/jxx/xuni/review/domain/Review.java
+++ b/src/main/java/com/jxx/xuni/review/domain/Review.java
@@ -25,6 +25,7 @@ public class Review {
     private String studyProductId;
     @Embedded
     private Content content;
+    private Integer likeTotalCnt;
     private LocalDateTime lastModifiedTime;
     private Boolean isDeleted;
 
@@ -33,6 +34,7 @@ public class Review {
         this.reviewer = reviewer;
         this.studyProductId = studyProductId;
         this.content = content;
+        this.likeTotalCnt = 0;
         this.lastModifiedTime = LocalDateTime.now();
         this.isDeleted = false;
     }
@@ -77,6 +79,14 @@ public class Review {
 
     public String receiveReviewerName() {
         return this.reviewer.getName();
+    }
+
+    public void onLikeEvent() {
+        likeTotalCnt += 1;
+    }
+
+    public void onLikeCancelEvent() {
+        likeTotalCnt -= 1;
     }
 
 }

--- a/src/main/java/com/jxx/xuni/review/domain/ReviewLike.java
+++ b/src/main/java/com/jxx/xuni/review/domain/ReviewLike.java
@@ -16,21 +16,25 @@ public class ReviewLike {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "review_like_id")
     private Long id;
-    private Long reviewId; // Review 간접 참조 키입니다.
     private Long memberId;
     private boolean isLiked;
     @Enumerated(value = EnumType.STRING)
     private LikeStatus likeStatus;
     private LocalDateTime createdTime;
     private LocalDateTime lastModifiedTime;
+    @ManyToOne
+    @JoinColumn(name = "review_id")
+    private Review review;
 
-    public ReviewLike(Long reviewId, Long memberId) {
-        this.reviewId = reviewId;
+    public ReviewLike(Long memberId, Review review) {
         this.memberId = memberId;
+        this.review = review;
         this.likeStatus = LikeStatus.INIT;
         this.isLiked = true;
         this.createdTime = LocalDateTime.now();
         this.lastModifiedTime = LocalDateTime.now();
+
+        this.review.onLikeEvent();
     }
 
     public void execute() {
@@ -46,11 +50,13 @@ public class ReviewLike {
     private void changeLikeStatus() {
         if (likeStatus.equals(LikeStatus.INIT) || likeStatus.equals(LikeStatus.LIKE)) {
             likeStatus = LikeStatus.DISLIKE;
+            review.onLikeCancelEvent();
             return;
         }
 
         if (likeStatus.equals(LikeStatus.DISLIKE)) {
             likeStatus = LikeStatus.LIKE;
+            review.onLikeEvent();
         }
     }
 }

--- a/src/main/java/com/jxx/xuni/review/domain/ReviewLikeRepository.java
+++ b/src/main/java/com/jxx/xuni/review/domain/ReviewLikeRepository.java
@@ -1,10 +1,19 @@
 package com.jxx.xuni.review.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 
     Optional<ReviewLike> findByReviewIdAndMemberId(Long reviewId, Long memberId);
+
+//    @Query("select rl from ReviewLike rl " +
+//            "join fetch rl.review r " +
+//            "where rl.review =:reviewId and rl.memberId =:memberId ")
+    @Query("select rl from ReviewLike rl " +
+            "join fetch rl.review r " +
+            "where r.id =:reviewId and rl.memberId =:memberId ")
+    Optional<ReviewLike> readWithReviewFetch(Long reviewId, Long memberId);
 }

--- a/src/main/java/com/jxx/xuni/review/domain/ReviewRepository.java
+++ b/src/main/java/com/jxx/xuni/review/domain/ReviewRepository.java
@@ -12,8 +12,4 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "where r.studyProductId =:studyProductId " +
             "and r.isDeleted = false ")
     List<Review> readBy(@Param("studyProductId") String studyProductId);
-
-    @Query(value = "select count(rl) from ReviewLike rl " +
-            "where rl.reviewId =:reviewId and rl.isLiked = true ")
-    Long countReviewLike(Long reviewId);
 }

--- a/src/main/java/com/jxx/xuni/review/dto/response/ReviewOneResponse.java
+++ b/src/main/java/com/jxx/xuni/review/dto/response/ReviewOneResponse.java
@@ -12,6 +12,6 @@ public record ReviewOneResponse(
         Long reviewerId,
         String reviewerName,
         Progress progress,
-        Long likeCnt
+        Integer likeCnt
 ) {
 }

--- a/src/test/java/com/jxx/xuni/review/application/ReviewLikeServiceTest.java
+++ b/src/test/java/com/jxx/xuni/review/application/ReviewLikeServiceTest.java
@@ -1,9 +1,9 @@
 package com.jxx.xuni.review.application;
 
-import com.jxx.xuni.review.domain.ReviewLike;
-import com.jxx.xuni.review.domain.ReviewLikeRepository;
+import com.jxx.xuni.review.domain.*;
 import com.jxx.xuni.support.ServiceCommon;
 import com.jxx.xuni.support.ServiceTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,9 +18,22 @@ class ReviewLikeServiceTest extends ServiceCommon {
     ReviewLikeService reviewLikeService;
     @Autowired
     ReviewLikeRepository reviewLikeRepository;
+    @Autowired
+    ReviewRepository reviewRepository;
+
+    Review review;
 
     @BeforeEach
     void beforeEach() {
+        review = reviewRepository.save(Review.builder()
+                .reviewer(Reviewer.of(100l, "reviewer1", Progress.HALF))
+                .content(Content.of(3, "reviewer's comment"))
+                .studyProductId("study-product-id")
+                .build());
+    }
+
+    @AfterEach
+    void afterEach() {
         reviewLikeRepository.deleteAll();
     }
 
@@ -28,7 +41,7 @@ class ReviewLikeServiceTest extends ServiceCommon {
     @Test
     void execute_first_time() {
         //given
-        Long reviewId = 123123l;
+        Long reviewId = review.getId();
         Long memberId = 1141l;
         //when
         reviewLikeService.execute(reviewId, memberId);
@@ -41,9 +54,9 @@ class ReviewLikeServiceTest extends ServiceCommon {
     @Test
     void execute_already_exist_and_liked_state_true() {
         //given
-        Long reviewId = 123123l;
+        Long reviewId = review.getId();
         Long memberId = 1141l;
-        reviewLikeRepository.save(new ReviewLike(reviewId, memberId));
+        reviewLikeRepository.save(new ReviewLike(memberId, review));
         //when
         reviewLikeService.execute(reviewId, memberId);
         //then
@@ -55,9 +68,9 @@ class ReviewLikeServiceTest extends ServiceCommon {
     @Test
     void execute_already_exist_and_liked_state_false() {
         //given
-        Long reviewId = 123123l;
+        Long reviewId = review.getId();
         Long memberId = 1141l;
-        reviewLikeRepository.save(new ReviewLike(reviewId, memberId));
+        reviewLikeRepository.save(new ReviewLike(memberId, review));
         reviewLikeService.execute(reviewId, memberId); // isLike 필드 -> false 로 변경
         //when
         reviewLikeService.execute(reviewId, memberId);

--- a/src/test/java/com/jxx/xuni/review/domain/ReviewLikeTest.java
+++ b/src/test/java/com/jxx/xuni/review/domain/ReviewLikeTest.java
@@ -1,6 +1,6 @@
 package com.jxx.xuni.review.domain;
 
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 
@@ -11,13 +11,22 @@ import static org.assertj.core.api.Assertions.*;
 
 class ReviewLikeTest {
 
+    Review review;
+
+    @BeforeEach
+    void beforeEach() {
+        review = Review.builder()
+                .reviewer(Reviewer.of(100l, "reviewer1", Progress.HALF))
+                .content(Content.of(3, "reviewer's comment"))
+                .studyProductId("study-product-id")
+                .build();
+    }
+
     @Test
     void init()  {
         Long memberId = 1l;
-        Long reviewId = 100l;
-        ReviewLike reviewLike = new ReviewLike(reviewId, memberId);
+        ReviewLike reviewLike = new ReviewLike(memberId, review);
 
-        assertThat(reviewLike.getReviewId()).isEqualTo(100l);
         assertThat(reviewLike.getLikeStatus()).isEqualTo(INIT);
         assertThat(reviewLike.isLiked()).isTrue();
     }
@@ -25,12 +34,12 @@ class ReviewLikeTest {
     @Test
     void execute() {
         Long memberId = 1l;
-        Long reviewId = 100l;
-        ReviewLike reviewLike = new ReviewLike(reviewId, memberId);
+        ReviewLike reviewLike = new ReviewLike(memberId, review);
 
         reviewLike.execute();
-        Assertions.assertThat(reviewLike.isLiked()).isFalse();
-        Assertions.assertThat(reviewLike.getLikeStatus()).isEqualTo(DISLIKE);
+        assertThat(reviewLike.getReview()).isEqualTo(review);
+        assertThat(reviewLike.isLiked()).isFalse();
+        assertThat(reviewLike.getLikeStatus()).isEqualTo(DISLIKE);
     }
 
 }

--- a/src/test/java/com/jxx/xuni/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/com/jxx/xuni/review/presentation/ReviewControllerTest.java
@@ -89,7 +89,7 @@ class ReviewControllerTest extends ReviewCommon {
                 10l,
                 "유니",
                 Progress.HALF,
-                5l);
+                5);
 
         ReviewOneResponse response2 = new ReviewOneResponse(
                 2l,
@@ -98,7 +98,7 @@ class ReviewControllerTest extends ReviewCommon {
                 15l,
                 "허니",
                 Progress.ALMOST,
-                0l);
+                0);
 
         List<ReviewOneResponse> responses = List.of(response1, response2);
 


### PR DESCRIPTION
1. 댓글에 좋아요를 누르는 행위보다 댓글을 조회하는 행위가 일반적으로 더 많이 발생할 것으로 예상됩니다. 이에 따라 조회 부분을 최적화하는게 성능 상 이점을 누릴 수 있지 않을까 고민했습니다.

기존의 구조
댓글 좋아요를 누르면 insert Query 가 한 번 발생합니다.
댓글 조회 시, 좋아요 수를 구해야 하기 때문에 카운트 쿼리가 상품에 달린 댓글 수 만큼 나가게 됩니다.

변경된 구조
리뷰 엔티티에서 좋아요 총 수를 필드로 가지고 있습니다. 이에 따라
댓글에 첫 좋아요를 누를 시 총 4번의 쿼리가 발생합니다. 이후 좋아요/좋아요 취소 요청을 보낼 경우 3번의 쿼리가 발생합니다. 이에 따라 응답 속도가 지연될 것으로 예상됩니다.

다만, 더 이상 좋아요 카운트 쿼리가 발생하지 않게 됩니다.