### PR TITLE
Fix/그룹 엔티티 기간, 시간 관련 사항 고려하지 못한 내용 규칙 추가 (#243)

### DIFF
--- a/src/main/java/com/jxx/xuni/group/domain/Group.java
+++ b/src/main/java/com/jxx/xuni/group/domain/Group.java
@@ -73,6 +73,13 @@ public class Group {
     public void verifyCreateRule() {
         checkGroupState(GATHERING);
         checkCapacityRange();
+        period.verifyPeriod();
+        time.verifyTime();
+    }
+    // TODO : 아직 미작업
+    public void initialize() {
+        groupMembers.add(enrollHost(host, this));
+        capacity.subtractOneLeftCapacity();
     }
 
     protected void checkCapacityRange() {

--- a/src/main/java/com/jxx/xuni/group/domain/GroupMember.java
+++ b/src/main/java/com/jxx/xuni/group/domain/GroupMember.java
@@ -33,7 +33,7 @@ public class GroupMember {
         this.group = group;
     }
 
-    public static GroupMember enrollHost(Host host, Group group) {
+    protected static GroupMember enrollHost(Host host, Group group) {
         return new GroupMember(host.getHostId(), host.getHostName(), group);
     }
 

--- a/src/main/java/com/jxx/xuni/group/domain/Period.java
+++ b/src/main/java/com/jxx/xuni/group/domain/Period.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+import static com.jxx.xuni.group.domain.exception.GroupExceptionMessage.INCORRECT_PERIOD;
+
 @Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,5 +23,11 @@ public class Period {
 
     public static Period of(LocalDate startDate, LocalDate endDate) {
         return new Period(startDate, endDate);
+    }
+
+    protected void verifyPeriod() {
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException(INCORRECT_PERIOD);
+        };
     }
 }

--- a/src/main/java/com/jxx/xuni/group/domain/Time.java
+++ b/src/main/java/com/jxx/xuni/group/domain/Time.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
 
+import static com.jxx.xuni.group.domain.exception.GroupExceptionMessage.INCORRECT_TIME;
+
 @Getter
 @Embeddable
 @NoArgsConstructor
@@ -21,5 +23,11 @@ public class Time {
 
     public static Time of(LocalTime startTime, LocalTime endTime) {
         return new Time(startTime, endTime);
+    }
+
+    protected void verifyTime() {
+        if (startTime.isAfter(endTime)) {
+            throw new IllegalArgumentException(INCORRECT_TIME);
+        }
     }
 }

--- a/src/main/java/com/jxx/xuni/group/domain/exception/GroupExceptionMessage.java
+++ b/src/main/java/com/jxx/xuni/group/domain/exception/GroupExceptionMessage.java
@@ -1,0 +1,11 @@
+package com.jxx.xuni.group.domain.exception;
+
+public class GroupExceptionMessage {
+
+    private GroupExceptionMessage() {
+
+    }
+
+    public static final String INCORRECT_PERIOD = "시작 일이 종료 일보다 늦을 수 없습니다";
+    public static final String INCORRECT_TIME = "시작 시간이 종료 시간보다 늦을 수 없습니다";
+}

--- a/src/test/java/com/jxx/xuni/group/domain/GroupTest.java
+++ b/src/test/java/com/jxx/xuni/group/domain/GroupTest.java
@@ -1,10 +1,7 @@
 package com.jxx.xuni.group.domain;
 
 import com.jxx.xuni.common.exception.NotPermissionException;
-import com.jxx.xuni.group.domain.exception.CapacityOutOfBoundException;
-import com.jxx.xuni.group.domain.exception.GroupJoinException;
-import com.jxx.xuni.group.domain.exception.GroupStartException;
-import com.jxx.xuni.group.domain.exception.NotAppropriateGroupStatusException;
+import com.jxx.xuni.group.domain.exception.*;
 import com.jxx.xuni.group.dto.request.GroupTaskForm;
 import com.jxx.xuni.common.domain.Category;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +17,7 @@ import java.util.List;
 
 import static com.jxx.xuni.common.exception.CommonExceptionMessage.BAD_REQUEST;
 import static com.jxx.xuni.group.domain.GroupStatus.*;
+import static com.jxx.xuni.group.domain.exception.GroupExceptionMessage.*;
 import static com.jxx.xuni.group.dto.response.GroupApiMessage.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -461,5 +459,43 @@ class GroupTest {
         //then
         assertThat(myTasks).extracting("isDone").containsExactly(true, false, false);
         assertThat(anotherMemberTasks).extracting("isDone").containsExactly(false, false, false);
+    }
+
+    @DisplayName("그룹 생성 시, 기간(period)은 시작일이 종료일보다 앞서야 한다. " +
+            "그렇지 않을 경우 IllegalArgumentException 예외" +
+            "INCORRECT_PERIOD 메시지 발생")
+    @Test
+    void init_role_1_period() {
+        //given
+        Group group = Group.builder()
+                .period(Period.of(LocalDate.of(2023, 12, 24), LocalDate.of(2022, 12, 24)))
+                .host(new Host(1l, "xuni"))
+                .capacity(Capacity.of(5))
+                .build();
+
+        Period period = group.getPeriod();
+
+        assertThatCode(() -> period.verifyPeriod())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(INCORRECT_PERIOD);
+    }
+
+    @DisplayName("그룹 생성 시, 시간(time)은 시작 시간이 종료 시간보다 앞서야 한다. " +
+            "그렇지 않을 경우 IllegalArgumentException 예외" +
+            "INCORRECT_TIME 메시지 발생")
+    @Test
+    void init_role_1_time() {
+        //given
+        Group group = Group.builder()
+                .time(Time.of(LocalTime.of(23, 0, 0), LocalTime.of(22, 0, 0)))
+                .host(new Host(1l, "xuni"))
+                .capacity(Capacity.of(5))
+                .build();
+
+        Time time = group.getTime();
+
+        assertThatCode(() -> time.verifyTime())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(INCORRECT_TIME);
     }
 }


### PR DESCRIPTION
1. 종료일은 시작일보다 앞설 수 없다.
2. 종료 시간은 시작 시간보다 앞설 수 없다.